### PR TITLE
Modifying the condition check in login()

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,9 +69,9 @@ async function login (silent = false) {
 
   const { username, password } = await getLoginCredential(silent);
 
-  if (!username || !password) {
+  if (!username) {
     if (!silent) {
-      vscode.window.showWarningMessage('需要帳密才能使用 VSCode PTT 噢！');
+      vscode.window.showWarningMessage('需要帳號才能使用 VSCode PTT 噢！');
     }
     return;
   }


### PR DESCRIPTION
1. password is not necessary if login as guest

## Fix what?

fix #19 

## Changes

- login()中不需確認password

## Note

看了ptt-client，password為空字串是OK的，不過最近ptt的guest太多(蟑螂盛行?)，無法用guest登入，就無法驗證XD