### PR TITLE
Bugfix/refresh button not working

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -195,7 +195,13 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(vscode.commands.registerCommand('ptt.refresh-article', () => {
     ptt.resetSearchCondition();
-    pttProvider.refresh();
+    const boards = store.getBoardNames();
+    boards.forEach(async (boardname: string) => {
+      store.release(boardname);
+      const articles = await ptt.getArticles(boardname);
+      store.add(boardname, articles);
+      pttProvider.refresh();
+    });
   }));
 
   context.subscriptions.push(vscode.commands.registerCommand('ptt.load-more-article', async (boardname: string) => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -48,6 +48,10 @@ class ArticleStore {
     return this.asList(boardname).length === 0;
   }
 
+  getBoardNames () {
+    return Object.keys(this.articleStore);
+  }
+
 }
 
 export default new ArticleStore();


### PR DESCRIPTION
## Fix what?

fix #21  (issue number)
無法重新整理

## Changes

你做了哪些改動？簡單的描述下，並條列說明

- change 1 store 新增可以拿到所有board names
- change 2 refresh 的時候，刪除舊有的文章，並且重新拿取所有 boards 的文章列表
